### PR TITLE
Fix: key error caused by csv generated by openFace deployed on Linux.

### DIFF
--- a/nerf_triplane/provider.py
+++ b/nerf_triplane/provider.py
@@ -251,7 +251,7 @@ class NeRFDataset:
         if self.opt.au45:
             import pandas as pd
             au_blink_info = pd.read_csv(os.path.join(self.root_path, 'au.csv'))
-            bs = au_blink_info[' AU45_r'].values
+            bs = au_blink_info.get('AU45_r', au_blink_info.get(' AU45_r')).values
         else:
             bs = np.load(os.path.join(self.root_path, 'bs.npy'))
             if self.opt.bs_area == "upper":


### PR DESCRIPTION
After deploying OpenFace on Linux and generating the au.csv file, the titles in the generated CSV lack spaces, unlike those generated by OpenFace on Windows, which include spaces. Therefore, a simple compatibility fix was implemented.