### PR TITLE
基于动态稀疏化的嘴部伪影消除方案

### DIFF
--- a/main.py
+++ b/main.py
@@ -35,6 +35,7 @@ if __name__ == '__main__':
     parser.add_argument('--upsample_steps', type=int, default=0, help="num steps up-sampled per ray (only valid when NOT using --cuda_ray)")
     parser.add_argument('--update_extra_interval', type=int, default=16, help="iter interval to update extra status (only valid when using --cuda_ray)")
     parser.add_argument('--max_ray_batch', type=int, default=4096, help="batch size of rays at inference to avoid OOM (only valid when NOT using --cuda_ray)")
+    parser.add_argument('--sparse_k', type=int, default=16,help='Number of active neurons to keep')
 
     ### loss set
     parser.add_argument('--warmup_step', type=int, default=10000, help="warm up steps")


### PR DESCRIPTION
### 基于动态稀疏化的嘴部伪影消除方案

#### 一、问题发现（实践观察）
在部署Synctalk模型进行实时语音驱动面部动画时，我们观察到以下关键问题：

1. **嘴部区域伪影**
- 音频特征可视化呈现明显的伪影
- 快速口型变化时产生闪烁伪影

2. **不确定性分布异常**
- 不确定性图在面部轮廓处持续高亮

```python:SyncTalk/nerf_triplane/network.py
# 原特征编码实现（问题根源）
def encode_x(self, xyz, bound):
    xy, yz, xz = self.split_xyz(xyz)
    feat_xy = self.encoder_xy(xy, bound=bound)
    feat_yz = self.encoder_yz(yz, bound=bound)
    feat_xz = self.encoder_xz(xz, bound=bound)
    return torch.cat([feat_xy, feat_yz, feat_xz], dim=-1)  # 直接拼接导致特征冗余
```

#### 二、解决方案设计（动态稀疏化）
提出层级式稀疏约束：

```python:SyncTalk/nerf_triplane/network.py
class KSparseLinear(nn.Linear):
    def __init__(self, in_features, out_features, k, bias=True):
        super().__init__(in_features, out_features, bias)
        self.k = min(k, in_features)  # 安全约束
        
    def forward(self, x):
        output = super().forward(x)
        actual_k = min(self.k, output.shape[-1])  # 动态k值调整
        values, _ = torch.topk(output, actual_k, dim=-1)
        threshold = values[..., -1].unsqueeze(-1)
        return output * (output >= threshold).float()  # 硬阈值滤波

# 在网络中的关键集成点
def encode_x(self, xyz, bound):
    # ... 原有特征提取 ...
    return self.sparse_layer(torch.cat([feat_xy, feat_yz, feat_xz], dim=-1))  # 新增稀疏层
```

#### 三、改进机制解析
1. **伪影消除原理**

- 抑制局部高频噪声：通过k=min(k,dim)实现自适应降噪
- 增强运动连续性：保留与发音肌肉协同运动相关的特征

2. **不确定性优化**
- 特征稀疏化降低对表面细节的过度敏感
- 动态阈值适应不同发音状态的特征复杂度

可视化对比：
未使用动态稀疏化：
![image](https://github.com/user-attachments/assets/83b1f3f7-e47b-4e53-bb11-82d0ecd13c49)
![image](https://github.com/user-attachments/assets/c033ba2f-067d-4bb3-a94d-4af6ab19410a)
![image](https://github.com/user-attachments/assets/fa6d8c3e-cd37-4215-a7d0-27c72ab9a613)
![image](https://github.com/user-attachments/assets/6fcd32c5-6ef6-432c-a363-1ac963876e34)

使用动态稀疏化
![image](https://github.com/user-attachments/assets/3e9347aa-fa1e-4b43-9643-15b06ab6f482)
![image](https://github.com/user-attachments/assets/bf1592cf-a075-450e-8b07-10f97ace3689)
![image](https://github.com/user-attachments/assets/07a1976e-3fef-444f-a1eb-d97fdbb0b8c6)
![image](https://github.com/user-attachments/assets/97b90c8f-cbd3-4f76-9be5-dd07704ca65d)

